### PR TITLE
Poc rust (un)/pause vm

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust"
+version = "0.1.0"
+authors = ["BenjiReis <benjamin.reis@vates.fr>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+xenctrl-sys = { git = "https://github.com/Wenzel/xenctrl-sys" }
+

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,9 @@
+Basic POC based on [Wendel's rust binding of libxc](https://github.com/Wenzel/xenctrl-sys) to pause and unpause a domain.
+
+# Requirements
+
+Install `cargo` & `rustc`
+
+# Usage
+
+In this folder run `cargo run {pause|unpause} <integer>` where integer is a valid domid.

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -8,7 +8,7 @@ use xenctrl_sys::xc_interface_open;
 
 fn help() {
   println!("usage:
-xenopsd-ng-cli {{pause|unpause}} <integer>
+cargo run {{pause|unpause}} <integer>
   pause/unpause a vm if the integer is a valid domid.");
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -38,9 +38,7 @@ fn main() {
       let num = &args[2];
       // parse the number
       let domid: u32 = match num.parse() {
-        Ok(n) => {
-          n
-        },
+        Ok(n) => n,
         Err(_) => {
           eprintln!("error: second argument not an integer");
           help();
@@ -65,8 +63,6 @@ fn main() {
       }
     },
     // all the other cases
-    _ => {
-      help();
-    }
+    _ => help(),
   }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,70 @@
+use std::env;
+use std::ptr::null_mut;
+use xenctrl_sys::xc_domain_pause;
+use xenctrl_sys::xc_domain_unpause;
+use xenctrl_sys::xc_interface;
+use xenctrl_sys::xc_interface_close;
+use xenctrl_sys::xc_interface_open;
+
+fn help() {
+  println!("usage:
+xenopsd-ng-cli {{pause|unpause}} <integer>
+  pause/unpause a vm if the integer is a valid domid.");
+}
+
+unsafe fn pause_vm(xc: *mut xc_interface ,domid: u32) {
+  let i = xc_domain_pause(xc, domid);
+  if (i != 0) {
+    eprintln!("error while pausing domain");
+  };
+}
+
+unsafe fn unpause_vm(xc: *mut xc_interface, domid: u32) {
+  let i = xc_domain_unpause(xc, domid);
+  if (i != 0) {
+    eprintln!("error while unpausing domain");
+  };
+}
+
+fn main() {
+  let args: Vec<String> = env::args().collect();
+
+  match args.len() {
+    // one command and one argument passed
+    3 => {
+      let cmd = &args[1];
+      let num = &args[2];
+      // parse the number
+      let domid: u32 = match num.parse() {
+        Ok(n) => {
+          n
+        },
+        Err(_) => {
+          eprintln!("error: second argument not an integer");
+          help();
+          return;
+        },
+      };
+      unsafe {
+        let xc = xc_interface_open(null_mut(), null_mut(), 0);
+        // parse the command
+        match &cmd[..] {
+          "pause" => pause_vm(xc, domid),
+          "unpause" => unpause_vm(xc, domid),
+          _ => {
+            eprintln!("error: invalid command");
+            help();
+          },
+        };
+        let i = xc_interface_close(xc);
+        if (i != 0) {
+          eprintln!("error while closing interface");
+        }
+      }
+    },
+    // all the other cases
+    _ => {
+      help();
+    }
+  }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -13,6 +13,7 @@ xenopsd-ng-cli {{pause|unpause}} <integer>
 }
 
 unsafe fn pause_vm(xc: *mut xc_interface ,domid: u32) {
+  println!("Pausing VM: {}, {:?}", domid, xc);
   let i = xc_domain_pause(xc, domid);
   if i != 0 {
     eprintln!("error while pausing domain");
@@ -20,6 +21,7 @@ unsafe fn pause_vm(xc: *mut xc_interface ,domid: u32) {
 }
 
 unsafe fn unpause_vm(xc: *mut xc_interface, domid: u32) {
+  println!("Unpausing VM: {}, {:?}", domid, xc);
   let i = xc_domain_unpause(xc, domid);
   if i != 0 {
     eprintln!("error while unpausing domain");

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -63,6 +63,6 @@ fn main() {
       }
     },
     // all the other cases
-    _ => help(),
+    _ => help()
   }
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -14,14 +14,14 @@ xenopsd-ng-cli {{pause|unpause}} <integer>
 
 unsafe fn pause_vm(xc: *mut xc_interface ,domid: u32) {
   let i = xc_domain_pause(xc, domid);
-  if (i != 0) {
+  if i != 0 {
     eprintln!("error while pausing domain");
   };
 }
 
 unsafe fn unpause_vm(xc: *mut xc_interface, domid: u32) {
   let i = xc_domain_unpause(xc, domid);
-  if (i != 0) {
+  if i != 0 {
     eprintln!("error while unpausing domain");
   };
 }
@@ -57,7 +57,7 @@ fn main() {
           },
         };
         let i = xc_interface_close(xc);
-        if (i != 0) {
+        if i != 0 {
           eprintln!("error while closing interface");
         }
       }


### PR DESCRIPTION
Basic POC based on [Wendel's rust binding of libxc](https://github.com/Wenzel/xenctrl-sys) to pause and unpause a domain.